### PR TITLE
correctly download zip files

### DIFF
--- a/app/models/batch_search_results.rb
+++ b/app/models/batch_search_results.rb
@@ -145,7 +145,7 @@ class BatchSearchResults
     export GENBANK_ROOT=$TMPDIR/genes
     export RAILS_ENV=#{Rails.env}
     export INFO_FILE=#{json_path_template('$SLURM_JOBID')}
-    export RESULTS=$TMPDIR/results.tar
+    export RESULTS=$TMPDIR/results.#{pkg}
     export PARAMS=#{serialize_params}
     export DATABASE_URL=#{ENV['DATABASE_URL']}
 

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -15,7 +15,7 @@ namespace :search do
         SearchResults.from_params(params).info.save(ENV['INFO_FILE'])
       }
       x.report("write pkg: ") {
-        if ENV['PKG_FORMAT'] == 'zip'
+        if params[:results_format] == 'zip'
           SearchResults.write_zip_to_file(params, ENV['RESULTS'], ENV['INFO_FILE'])
         else
           SearchResults.write_tar_to_file(params, ENV['RESULTS'], ENV['INFO_FILE'])


### PR DESCRIPTION
There's a bug where users choose tar files, but it always gets archived as a .tar.gz. So users can't open a .zip file because it's actually a .tar.gz.

I believe it's because `ENV['PKG_FORMAT'] ` is never set, so the job default to tar, then the batch script copies that file and erroneously calls it a .zip.