### PR TITLE
add ps to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,8 @@ RUN dnf install -y \
 
 RUN dnf install -y \
         gcc gcc-c++ gdb make curl curl-devel openssl-devel libxml2-devel \
-        sqlite-devel \
-        readline-devel \
-        redhat-rpm-config \
-        shared-mime-info \
-        mariadb-devel \
-        nodejs \
-        libnsl \
+        sqlite-devel readline-devel redhat-rpm-config shared-mime-info \
+        mariadb-devel nodejs libnsl procps-ng \
     && dnf clean all && rm -rf /var/cache/dnf/*
 
 # install Ruby


### PR DESCRIPTION
add `procps-ng` (to get `ps`) to dockerfile and fix the install step a bit to combine a few things to have fewer lines.