### PR TITLE
rework alignments

### DIFF
--- a/align.sbatch
+++ b/align.sbatch
@@ -26,7 +26,7 @@ module load pcp
 cp $WORKDIR/genes.tar.gz $TMPDIR
 time (cd $TMPDIR; tar xzf genes.tar.gz)
 
-GENBANK_ROOT=$TMPDIR/genes ALIGNMENTS_CACHE_PATH=$WORKDIR/genes.db bin/rake pipeline:alignpcp
+GENBANK_ROOT=$TMPDIR/genes bin/rake pipeline:align
 
 
 # tar up genes with alignments and copy back

--- a/submit_pipeline.sh
+++ b/submit_pipeline.sh
@@ -25,15 +25,7 @@ id=$(sbatch --dependency=afterok:${id##* } update_species_metrics.sbatch)
 id=$(sbatch --dependency=afterok:${id##* } clean_database.sbatch)
 id=$(sbatch --dependency=afterok:${id##* } update_species_metrics.sbatch)
 
-# FIXME: if executing this job alignment without TIMEOUT and no genes.db cache file this job will likely exceed
-# the walltime and fail; since the copy back to project is done at the end,
-# if the walltime kills an alignment job all work is lost
-#
-# consider adding logic here to determine if alignment cache is available,
-# if not run align.pbs three times, first with a timeout of 10m, second with 60m and finally without a timeout,
-# copying results back in between; or add logic here and submit align.pbs several times with different timeouts
 id=$(sbatch --dependency=afterok:${id##* } align.sbatch)
 id=$(sbatch --dependency=afterok:${id##* } update_species_metrics.sbatch)
-id=$(sbatch --dependency=afterok:${id##* } update_alignment_cache.sbatch)
 
 id=$(sbatch --dependency=afterok:${id##* } report_species_metrics.sbatch)


### PR DESCRIPTION
This changes the alignments algorithm a bit to use `parallel`. The main sbatch file also calls this task favoring it instead of `pcp`.

This rake task does not use the alignment cache, so that bit has been removed from `submit_pipeline.sh`. It also is very stable so there's no need for that comment anymore. (I guess using `pcp` was the cause of the instability?).

