### PR TITLE
Add mariadb client package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN dnf install -y \
 RUN dnf install -y \
         gcc gcc-c++ gdb make curl curl-devel openssl-devel libxml2-devel \
         sqlite-devel readline-devel redhat-rpm-config shared-mime-info \
-        mariadb-devel nodejs libnsl procps-ng \
+        mariadb-devel nodejs libnsl procps-ng mariadb \
     && dnf clean all && rm -rf /var/cache/dnf/*
 
 # install Ruby


### PR DESCRIPTION
Need this so that initContainer can run a loop to wait for MariaDB to start.  I could just let the container fail and go into Kubernetes crash loop but rather just have init container wait for the MariaDB service to be started.  I could use some other container but it's a lot simpler Helm logic if everything uses the same container.