### PR TITLE
dont mkdir and fix gems for latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,10 @@ source 'https://rubygems.org'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '5.0.6'
 
+# FIXME: after upgrading rails may have to change this
+# https://github.com/ruby/bigdecimal#which-version-should-you-select
+gem 'bigdecimal', '1.3.5'
+
 # be able to use either mysql or sqlite3
 gem 'sqlite3', '~> 1.3', '< 1.4'
 gem 'mysql2', '~> 0.4.1'
@@ -63,7 +67,6 @@ gem 'activerecord-import'
 gem 'parallel'
 
 
-gem 'gdbm'
 # install/use for testing purposes
 # bin/bundle exec derailed bundle:mem
 # 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
     arel (7.1.4)
     autoprefixer-rails (10.4.2.0)
       execjs (~> 2)
+    bigdecimal (1.3.5)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     bio (2.0.3)
@@ -74,7 +75,6 @@ GEM
     ffi (1.15.5)
     font-awesome-sass (4.7.0)
       sass (>= 3.2)
-    gdbm (2.1.0)
     geokit (1.13.1)
     geokit-rails (2.3.2)
       geokit (~> 1.5)
@@ -211,6 +211,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord-import
   autoprefixer-rails
+  bigdecimal (= 1.3.5)
   bio
   bootstrap-sass (~> 3.3)
   bootstrap_form (~> 2.5)
@@ -218,7 +219,6 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   dotenv-rails
   font-awesome-sass (~> 4.6)
-  gdbm
   geokit-rails
   jbuilder (~> 2.0)
   jquery-rails

--- a/app/models/batch_search_results.rb
+++ b/app/models/batch_search_results.rb
@@ -46,8 +46,6 @@ class BatchSearchResults
   # should have added that a long very long time ago
   # ################################################
   def submit_job
-    # FIXME: protect against crash?
-    results_root.mkpath
 
     # generate headers and insert into batch script INSTEAD OF command line args
     # skip #!/bin/bash and then do that


### PR DESCRIPTION
Don't make the result directory on the webserver as the script already does that.  This will allow us to mount that as RO.

The Gemfile updates are one, `gdbm` isn't used anymore and now I know why it wasn't commited before. It's a system gem that OOD can't find.  `bigdecimal` was an issue I should have caught when I upgraded rails and the ruby version.