### PR TITLE
job to use real db url

### DIFF
--- a/app/models/batch_search_results.rb
+++ b/app/models/batch_search_results.rb
@@ -145,7 +145,7 @@ class BatchSearchResults
     export INFO_FILE=#{json_path_template('$SLURM_JOBID')}
     export RESULTS=$TMPDIR/results.#{pkg}
     export PARAMS=#{serialize_params}
-    export DATABASE_URL=#{ENV['DATABASE_URL']}
+    export DATABASE_URL=#{ENV['REAL_DATABASE_URL']}
 
     # execute command
     singularity exec #{Configuration.sif_path} /app/bin/bundle exec /app/bin/db search


### PR DESCRIPTION
job to use real db url becuase inside the container it's `/data` and outside it's using `/fs/project` a real filesystem.