### PR TITLE
change directory to a real working directory

### DIFF
--- a/app/models/batch_search_results.rb
+++ b/app/models/batch_search_results.rb
@@ -59,7 +59,7 @@ class BatchSearchResults
       job_name: "phylogatr_search",
       wall_time: 3600,
       # native: [ "--partition", "quick", "--nodes", "1", "--ntasks-per-node", "1"  ]
-      native: [ "--nodes", "1", "--ntasks-per-node", "2"  ]
+      native: [ "--nodes", "1", "--ntasks-per-node", "2", -D, results_root  ]
     ))
   end
 


### PR DESCRIPTION
Jobs are failing right now we believe because the working directory is `/app` which only exists inside the container. So this uses the -D flag to tell slurm to use a different working directory.